### PR TITLE
Add Docker swarm to portably manage Encourse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /client/node_modules/
 /client/package-lock.json
 **.old.*
+/secrets.env
 
 ./package-lock.json
 

--- a/README.md
+++ b/README.md
@@ -1,30 +1,47 @@
 # encourse
- 
-## Server
- 
+
+## Hosting with Docker
+
+Self hosting with Docker swarms is easy and portable. To start and daemonize the
+swarm:
+```
+docker-compose up -d
+```
+
+Made some changes? Just restart the container you need:
+```
+docker-compose restart encourse-js   # or encourse-java
+```
+
+The swarm also includes PGAdmin for easy viewing and administration of the
+Postgres database. Default username is `postgres@encourse.edu` with a password
+specified in `secrets.env` (must be created).
+
+## Hosting without Docker
+
 ### Installations on Ubuntu Server Edition
- 
+
  Ensure that the following packages are installed and up to date:
- 
+
  1. Java -    `apt-get install default-jdk`
  2. Maven -   `apt-get install maven`
  3. Node.js - `apt-get install nodejs`
  4. NPM -     `apt-get install npm`
- 
+
 ### Commands to Serve Client Files
- 
+
  In directory encourse/client, run the following commands:
- 
+
  1. Create production build -    `npm run-script build`
  2. Begin serving on port 5000 - `serve -s build`
- 
+
 ### Commands to Run Spring Server
- 
+
  In directory encourse/server, run the following commands:
- 
+
  1. Build and test maven project - `mvn clean package install`
  2. Run server on port 40797 -     `mvn spring-boot:run`
- 
+
 ## Frontend
  Setup File Watcher :
   1. npm install -g node-sass
@@ -41,8 +58,8 @@
 
 ### Postgres
 
- Create files `pgdb_user.txt` and `pgdb_password.txt` that contain the admin credentials for the PostgreSQL database.  
- Once Docker is installed (it expects Linux containers) you can run `docker-compose up` to start the database  
+ Create files `pgdb_user.txt` and `pgdb_password.txt` that contain the admin credentials for the PostgreSQL database.
+ Once Docker is installed (it expects Linux containers) you can run `docker-compose up` to start the database
  If you have issues with running Docker after multiple runs, you can run `./armaggedon.sh` to remove volumes and networks to start fresh. Note that this will make Docker re-download images for building and delete any saved data.
 
 
@@ -54,13 +71,13 @@
     local.postgres.password=
     spring.security.user.name=
     spring.security.user.password=
- 
+
  You must make the postgres credentials here the same as the files created for the Postgres setup. The credentials afterwards are for any REST call made until authentication is finished.
- 
- If there are compile errors related to security or xml binding then try the following:  
-  If you are running JDK 8, ensure that your distro has JAXB and remove the following lines from your `pom.xml`:  
-  If you are running JDK 9, add the following lines to your `pom.xml`:  
-  
+
+ If there are compile errors related to security or xml binding then try the following:
+  If you are running JDK 8, ensure that your distro has JAXB and remove the following lines from your `pom.xml`:
+  If you are running JDK 9, add the following lines to your `pom.xml`:
+
     <dependency>
         <groupId>javax.xml.bind</groupId>
         <artifactId>jaxb-api</artifactId>
@@ -81,9 +98,8 @@
         <artifactId>activation</artifactId>
         <version>1.1.1</version>
     </dependency>
-    
+
  ### Authentication
- 
- 1. Hash a new 4 round password here: [BCrypt](https://www.browserling.com/tools/bcrypt)  
- 2. Change the password to your account in `StartupFeed.java` 
-    
+
+ 1. Hash a new 4 round password here: [BCrypt](https://www.browserling.com/tools/bcrypt)
+ 2. Change the password to your account in `StartupFeed.java`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,73 @@
+---
+version: "3.7"
+services:
+
+  encourse-java:
+    build:
+      context: ./docker/encourse-java
+    image: encourse-java
+    container_name: encourse-java
+    ports:
+      - "40797:40797"
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=America/Indianapolis
+    volumes:
+      - ./server:/encourse/server:Z
+    restart: unless-stopped
+
+  encourse-js:
+    build:
+      context: ./docker/encourse-js
+    image: encourse-js
+    container_name: encourse-js
+    ports:
+      - "5000:5000"
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=America/Indianapolis
+    volumes:
+      - ./client:/encourse/client:Z
+    restart: unless-stopped
+
+  postgres:
+    image: postgres
+    container_name: postgres
+    env_file:
+      - secrets.env
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=America/Indianapolis
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "postgres:5432"]
+      interval: 30s
+      timeout: 30s
+      retries: 5
+    volumes:
+      - encourse-postgres:/var/lib/postgresql/data:z
+    restart: unless-stopped
+
+  pgadmin:
+    image: dpage/pgadmin4
+    container_name: pgadmin
+    env_file:
+      - secrets.env
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=America/Indianapolis
+      - PGADMIN_DEFAULT_EMAIL=postgres@encourse.edu
+    ports:
+      - "5480:80"
+    volumes:
+      - encourse-pgadmin:/var/lib/pgadmin:z
+    restart: unless-stopped
+
+volumes:
+  encourse-postgres:
+  encourse-pgadmin:

--- a/docker/encourse-java/Dockerfile
+++ b/docker/encourse-java/Dockerfile
@@ -1,0 +1,7 @@
+FROM maven:3-jdk-8-slim
+
+ADD ./entrypoint.sh /entrypoint.sh
+
+EXPOSE 40797
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/encourse-java/entrypoint.sh
+++ b/docker/encourse-java/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+cd /encourse/server/ \
+    && mvn clean package install \
+    && mvn spring-boot:run

--- a/docker/encourse-js/Dockerfile
+++ b/docker/encourse-js/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:carbon-jessie-slim
+# Needs to be x64 node v8 on glibc (not musl -- as in no Alpine image).
+
+RUN npm install -g serve
+
+ADD ./entrypoint.sh /entrypoint.sh
+
+EXPOSE 5000
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/encourse-js/entrypoint.sh
+++ b/docker/encourse-js/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+cd /encourse/client/ \
+    && npm install \
+    && npm run build \
+    && serve -s build

--- a/secrets.env.template
+++ b/secrets.env.template
@@ -1,0 +1,3 @@
+# vim:set ft=sh
+POSTGRES_PASSWORD=password
+PGADMIN_DEFAULT_PASSWORD=password


### PR DESCRIPTION
Thought I could help onboard (_Enboard?_) new contributors by simplifying the hosting process. At the moment still requires some initial configuration, e.g. secret files, initializing Postgres (exactly once) with `init.sql`, etc. but in the future perhaps these can be replaced with "sensible defaults" so it's a one-click solution.

This should work nicely on VPS's too, Docker is pretty low-overhead.

Enjoy, let me know if you have questions.